### PR TITLE
Moved dotenv config() call to avoid order-of-execution problems

### DIFF
--- a/EP 4/src/index.ts
+++ b/EP 4/src/index.ts
@@ -1,6 +1,1 @@
-import { config } from 'dotenv'
-import { resolve } from 'path'
-
-config({ path: resolve(__dirname, '..', '.env') })
-
 import './client'

--- a/EP 4/src/keys/index.ts
+++ b/EP 4/src/keys/index.ts
@@ -2,7 +2,7 @@ import { config } from "dotenv"
 import { resolve } from "path"
 import { Keys } from '../types'
 
-//Doing this here instead of on src/index.ts and ___ guarantees the keys are loaded when other files import keys
+//Doing this here instead of on src/index.ts and scripts/deploy.ts (and elsewhere) guarantees the keys are loaded when other files import them
 //Since this command is the only reason those files had the 'config' and 'resolve' import, it cleans them up too
 config({ path: resolve(__dirname, '..', '.env') })
 

--- a/EP 4/src/keys/index.ts
+++ b/EP 4/src/keys/index.ts
@@ -1,4 +1,10 @@
+import { config } from "dotenv"
+import { resolve } from "path"
 import { Keys } from '../types'
+
+//Doing this here instead of on src/index.ts and ___ guarantees the keys are loaded when other files import keys
+//Since this command is the only reason those files had the 'config' and 'resolve' import, it cleans them up too
+config({ path: resolve(__dirname, '..', '.env') })
 
 const keys: Keys = {
   clientToken: process.env.CLIENT_TOKEN ?? 'nil',

--- a/EP 4/src/pages/help.ts
+++ b/EP 4/src/pages/help.ts
@@ -1,5 +1,4 @@
 import { ActionRowBuilder, ButtonBuilder, SelectMenuBuilder } from "@discordjs/builders"
-import { debug } from "console"
 import { APIEmbedField, ButtonStyle, EmbedBuilder, InteractionReplyOptions, SelectMenuOptionBuilder } from "discord.js"
 import CategoryRoot from  '../commands'
 import { chunk, createId, readId } from "../utils"

--- a/EP 4/src/scripts/deploy.ts
+++ b/EP 4/src/scripts/deploy.ts
@@ -1,8 +1,3 @@
-import { config } from 'dotenv'
-import { resolve } from 'path'
-
-config({ path: resolve(__dirname, '..', '..', '.env') })
-
 import { REST, Routes, APIUser } from 'discord.js'
 import commands from '../commands'
 import keys from '../keys'

--- a/EP 4/src/utils/chunk.ts
+++ b/EP 4/src/utils/chunk.ts
@@ -5,7 +5,7 @@ export function chunk<T>(items: T[], chunk: number): T[][] {
   const chunks: T[][] = []
 
   // For loop; Loop until i is more than our items available; Increment by the given chunk;
-  // Each iteraction copy push targeted chunk from the passed items to the chunks array
+  // Each interaction copy push targeted chunk from the passed items to the chunks array
   for (let i = 0; i < items.length; i += chunk) {
     chunks.push(items.slice(i, i + chunk))
   }


### PR DESCRIPTION
- Moved the dotenv config() call to keys/index.ts (avoids problems of order-of-execution, and cleans up some files)
- Removed the dotenv config() calls (and the then-unused imports) from src/index.ts and scripts/deploy.ts
- Removed unused import of 'debug' from pages/help.ts
- Fixed small typo in util/chunks.ts